### PR TITLE
Sender and Identity API

### DIFF
--- a/api/src/main/java/net/okocraft/okochat/api/identity/ChannelIdentity.java
+++ b/api/src/main/java/net/okocraft/okochat/api/identity/ChannelIdentity.java
@@ -1,0 +1,9 @@
+package net.okocraft.okochat.api.identity;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface ChannelIdentity extends Identity {
+
+    @NotNull String getName();
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/identity/Identified.java
+++ b/api/src/main/java/net/okocraft/okochat/api/identity/Identified.java
@@ -1,0 +1,9 @@
+package net.okocraft.okochat.api.identity;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface Identified {
+
+    @NotNull Identity identity();
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/identity/Identities.java
+++ b/api/src/main/java/net/okocraft/okochat/api/identity/Identities.java
@@ -1,0 +1,23 @@
+package net.okocraft.okochat.api.identity;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+final class Identities {
+
+    record Player(@NotNull UUID uuid) implements PlayerIdentity {
+        @Override
+        public @NotNull UUID getUniqueId() {
+            return this.uuid;
+        }
+    }
+
+    record Channel(@NotNull String name) implements ChannelIdentity {
+        @Override
+        public @NotNull String getName() {
+            return this.name;
+        }
+    }
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/identity/Identity.java
+++ b/api/src/main/java/net/okocraft/okochat/api/identity/Identity.java
@@ -1,0 +1,26 @@
+package net.okocraft.okochat.api.identity;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public interface Identity extends Identified {
+
+    @Contract("_ -> new")
+    static @NotNull PlayerIdentity player(@NotNull UUID uuid) {
+        return new Identities.Player(Objects.requireNonNull(uuid));
+    }
+
+    @Contract("_ -> new")
+    static @NotNull ChannelIdentity channel(@NotNull String name) {
+        return new Identities.Channel(Objects.requireNonNull(name));
+    }
+
+    @Override
+    default @NotNull Identity identity() {
+        return this;
+    }
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/identity/PlayerIdentity.java
+++ b/api/src/main/java/net/okocraft/okochat/api/identity/PlayerIdentity.java
@@ -1,0 +1,11 @@
+package net.okocraft.okochat.api.identity;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public interface PlayerIdentity extends Identity {
+
+    @NotNull UUID getUniqueId();
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/sender/ConsoleSender.java
+++ b/api/src/main/java/net/okocraft/okochat/api/sender/ConsoleSender.java
@@ -1,0 +1,4 @@
+package net.okocraft.okochat.api.sender;
+
+public interface ConsoleSender extends Sender {
+}

--- a/api/src/main/java/net/okocraft/okochat/api/sender/PlayerSender.java
+++ b/api/src/main/java/net/okocraft/okochat/api/sender/PlayerSender.java
@@ -1,0 +1,18 @@
+package net.okocraft.okochat.api.sender;
+
+import net.okocraft.okochat.api.identity.Identified;
+import net.okocraft.okochat.api.identity.Identity;
+import net.okocraft.okochat.api.identity.PlayerIdentity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public interface PlayerSender extends Sender, Identified {
+
+    @NotNull UUID getUniqueId();
+
+    @Override
+    default @NotNull PlayerIdentity identity() {
+        return Identity.player(this.getUniqueId());
+    }
+}

--- a/api/src/main/java/net/okocraft/okochat/api/sender/Sender.java
+++ b/api/src/main/java/net/okocraft/okochat/api/sender/Sender.java
@@ -1,0 +1,23 @@
+package net.okocraft.okochat.api.sender;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.util.TriState;
+import org.jetbrains.annotations.NotNull;
+
+public interface Sender {
+
+    String getName();
+
+    void sendMessage(@NotNull Component message);
+
+    default boolean hasPermission(@NotNull String node) {
+        return this.hasPermission(node, false);
+    }
+
+    default boolean hasPermission(@NotNull String node, boolean defaultValue) {
+        return this.getPermissionValue(node).toBooleanOrElse(defaultValue);
+    }
+
+    TriState getPermissionValue(@NotNull String node);
+
+}

--- a/api/src/main/java/net/okocraft/okochat/api/sender/SenderProvider.java
+++ b/api/src/main/java/net/okocraft/okochat/api/sender/SenderProvider.java
@@ -1,0 +1,16 @@
+package net.okocraft.okochat.api.sender;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SenderProvider {
+
+    @NotNull ConsoleSender getConsole();
+
+    @NotNull Optional<PlayerSender> findPlayerByName(@NotNull String name);
+
+    @NotNull Optional<PlayerSender> findPlayerByUUID(@NotNull UUID uuid);
+
+}

--- a/core/src/main/java/net/okocraft/okochat/core/member/ChannelMember.java
+++ b/core/src/main/java/net/okocraft/okochat/core/member/ChannelMember.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.util.TriState;
  * チャンネルメンバーの抽象クラス
  * @author ucchy
  */
+@Deprecated(forRemoval = true)
 public interface ChannelMember {
 
     /**

--- a/core/src/main/java/net/okocraft/okochat/core/member/ChannelMemberOther.java
+++ b/core/src/main/java/net/okocraft/okochat/core/member/ChannelMemberOther.java
@@ -12,6 +12,7 @@ import net.okocraft.okochat.core.util.BlockLocation;
  * 任意の内容を設定できるChannelMember
  * @author ucchy
  */
+@Deprecated(forRemoval = true)
 public class ChannelMemberOther implements ChannelMember {
 
     private String id;


### PR DESCRIPTION
ChannelMember is now separated to

- Identity - to use channel members, hide-list, etc...
- Sender - the interface to be implemented by the platform

The APIs are experimental. And this PR does not modify any logic.